### PR TITLE
Bumped :meck library version, added delete/3 function

### DIFF
--- a/lib/ex_meck.ex
+++ b/lib/ex_meck.ex
@@ -25,6 +25,10 @@ defmodule ExMeck do
   """
   def expect(mod, fun, expectation), do: :meck.expect(mod, fun, expectation)
 
+  @doc """
+  Deletes the expectation created with expect/3
+  """
+  def delete(mod, fun, arity), do: :meck.delete(mod, fun, arity)
 
   @doc """
   Verify wheter the history of the mocked module mod contains a call that satisfies specification spec.
@@ -44,8 +48,8 @@ defmodule ExMeck do
     history = :meck.history(mod)
     case Enum.any?(history, fn call -> matches? spec, call end) do
       true  -> true
-      false -> :timer.sleep 100
-               contains?(mod, spec, timeout - 100)
+      false -> :timer.sleep 20
+               contains?(mod, spec, timeout - 20)
     end
   end
 
@@ -60,8 +64,8 @@ defmodule ExMeck do
     history = :meck.history(mod)
     case Enum.filter(history, fn call -> matches? spec, call end) do
       [match|_]  -> {:ok, match}
-      []         -> :timer.sleep 100
-                    contains(mod, spec, timeout - 100)
+      []         -> :timer.sleep 20
+                    contains(mod, spec, timeout - 20)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule ExMeck.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [ 
-      {:meck, "~> 0.8.8"},
+      {:meck, "~> 0.8.11"},
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:gen_state_machine, "~> 2.0", only: :test},
       {:propcheck, "~> 1.0", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "gen_state_machine": {:hex, :gen_state_machine, "2.0.1", "85efd5a0376929c3a4246dd943e17564a2908c7ddd7acd242d84594e785d83f8", [:mix], [], "hexpm"},
-  "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.11", "2c39e15ec87d847da6cf69b4a1c4af3fd850ae2a272e719e0e8751a7fe54771f", [:rebar3], [], "hexpm"},
   "propcheck": {:hex, :propcheck, "1.0.4", "f83174301b637bce011a4ebf0e4f10e9bae38d6eefebdd117677c7884bc99aa4", [:mix], [{:proper, "~> 1.2.0", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
   "proper": {:hex, :proper, "1.2.0", "1466492385959412a02871505434e72e92765958c60dba144b43863554b505a4", [:make, :mix, :rebar3], [], "hexpm"},
 }

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 Code.load_file("test/switch.ex")
 Code.load_file("test/timer.ex")
 ExUnit.start()
+PropCheck.App.start(1,2)


### PR DESCRIPTION
Bumped meck library version to latest 0.8.11
Reduced delay between consecutive history lookups to 20ms.
Added delete/3 function which maps directly to `:meck.delete/3`
Added starting of propcheck app in test_helpers.exs to enable CI in PRs.
